### PR TITLE
Allow BoxView::Document.delete to return a successful but empty response (204)

### DIFF
--- a/lib/boxview/document.rb
+++ b/lib/boxview/document.rb
@@ -246,6 +246,7 @@ module BoxView
       def delete_response_handler(response)
         case response.code
         when 200
+        when 204
         else
           raise BoxView::Errors::DocumentDeletionFailed.new(response)
         end

--- a/spec/lib/boxview/document_spec.rb
+++ b/spec/lib/boxview/document_spec.rb
@@ -95,3 +95,15 @@ describe BoxView::Document, '#create' do
     expect(200..202).to cover(response.code)
   end
 end
+describe BoxView::Document, '#delete' do
+  let(:mock_response) { double('204 Response', { :code => 204, :body => '' }) }
+
+  before do
+    allow(BoxView).to receive(:delete).and_return(mock_response)
+  end
+
+  it 'should return an empty string when sent a good request resulting in a 204 (empty) response' do
+    response = BoxView::Document.delete document_id: "xyz"
+    expect(response.body).to eq ''
+  end
+end


### PR DESCRIPTION
The Box View API seems to return a 204 response when deleting files (at least for me).  Even though this is a successful response code (2xx), `BoxView::Document.delete_response_handler` was raising an error.  This adds a spec to catch this scenario and returns the empty response.